### PR TITLE
Replace Murmur3 32bit hash with 128bit hash - based on fingerprint2.js

### DIFF
--- a/fingerprint.js
+++ b/fingerprint.js
@@ -101,75 +101,207 @@
         keys.push(this.getCanvasFingerprint());
       }
       if(this.hasher){
-        return this.hasher(keys.join('###'), 31);
+        return this.hasher(keys.join('~~~'), 31);
       } else {
-        return this.murmurhash3_32_gc(keys.join('###'), 31);
+        return this.x64hash128(keys.join("~~~"), 31);
       }
     },
 
-    /**
-     * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
-     *
-     * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
-     * @see http://github.com/garycourt/murmurhash-js
-     * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
-     * @see http://sites.google.com/site/murmurhash/
-     *
-     * @param {string} key ASCII only
-     * @param {number} seed Positive integer only
-     * @return {number} 32-bit positive integer hash
-     */
 
-    murmurhash3_32_gc: function(key, seed) {
-      var remainder, bytes, h1, h1b, c1, c2, k1, i;
+    /// MurmurHash3 related functions
 
-      remainder = key.length & 3; // key.length % 4
-      bytes = key.length - remainder;
-      h1 = seed;
-      c1 = 0xcc9e2d51;
-      c2 = 0x1b873593;
-      i = 0;
+    //
+    // Given two 64bit ints (as an array of two 32bit ints) returns the two
+    // added together as a 64bit int (as an array of two 32bit ints).
+    //
+    x64Add: function(m, n) {
+      m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff];
+      n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff];
+      var o = [0, 0, 0, 0];
+      o[3] += m[3] + n[3];
+      o[2] += o[3] >>> 16;
+      o[3] &= 0xffff;
+      o[2] += m[2] + n[2];
+      o[1] += o[2] >>> 16;
+      o[2] &= 0xffff;
+      o[1] += m[1] + n[1];
+      o[0] += o[1] >>> 16;
+      o[1] &= 0xffff;
+      o[0] += m[0] + n[0];
+      o[0] &= 0xffff;
+      return [(o[0] << 16) | o[1], (o[2] << 16) | o[3]];
+    },
 
-      while (i < bytes) {
-          k1 =
-            ((key.charCodeAt(i) & 0xff)) |
-            ((key.charCodeAt(++i) & 0xff) << 8) |
-            ((key.charCodeAt(++i) & 0xff) << 16) |
-            ((key.charCodeAt(++i) & 0xff) << 24);
-        ++i;
-
-        k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff;
-        k1 = (k1 << 15) | (k1 >>> 17);
-        k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff;
-
-        h1 ^= k1;
-            h1 = (h1 << 13) | (h1 >>> 19);
-        h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff;
-        h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
+    //
+    // Given two 64bit ints (as an array of two 32bit ints) returns the two
+    // multiplied together as a 64bit int (as an array of two 32bit ints).
+    //
+    x64Multiply: function(m, n) {
+      m = [m[0] >>> 16, m[0] & 0xffff, m[1] >>> 16, m[1] & 0xffff];
+      n = [n[0] >>> 16, n[0] & 0xffff, n[1] >>> 16, n[1] & 0xffff];
+      var o = [0, 0, 0, 0];
+      o[3] += m[3] * n[3];
+      o[2] += o[3] >>> 16;
+      o[3] &= 0xffff;
+      o[2] += m[2] * n[3];
+      o[1] += o[2] >>> 16;
+      o[2] &= 0xffff;
+      o[2] += m[3] * n[2];
+      o[1] += o[2] >>> 16;
+      o[2] &= 0xffff;
+      o[1] += m[1] * n[3];
+      o[0] += o[1] >>> 16;
+      o[1] &= 0xffff;
+      o[1] += m[2] * n[2];
+      o[0] += o[1] >>> 16;
+      o[1] &= 0xffff;
+      o[1] += m[3] * n[1];
+      o[0] += o[1] >>> 16;
+      o[1] &= 0xffff;
+      o[0] += (m[0] * n[3]) + (m[1] * n[2]) + (m[2] * n[1]) + (m[3] * n[0]);
+      o[0] &= 0xffff;
+      return [(o[0] << 16) | o[1], (o[2] << 16) | o[3]];
+    },
+    //
+    // Given a 64bit int (as an array of two 32bit ints) and an int
+    // representing a number of bit positions, returns the 64bit int (as an
+    // array of two 32bit ints) rotated left by that number of positions.
+    //
+    x64Rotl: function(m, n) {
+      n %= 64;
+      if (n === 32) {
+        return [m[1], m[0]];
       }
-
-      k1 = 0;
-
-      switch (remainder) {
-        case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-        case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-        case 1: k1 ^= (key.charCodeAt(i) & 0xff);
-
-        k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
-        k1 = (k1 << 15) | (k1 >>> 17);
-        k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
-        h1 ^= k1;
+      else if (n < 32) {
+        return [(m[0] << n) | (m[1] >>> (32 - n)), (m[1] << n) | (m[0] >>> (32 - n))];
       }
+      else {
+        n -= 32;
+        return [(m[1] << n) | (m[0] >>> (32 - n)), (m[0] << n) | (m[1] >>> (32 - n))];
+      }
+    },
+    //
+    // Given a 64bit int (as an array of two 32bit ints) and an int
+    // representing a number of bit positions, returns the 64bit int (as an
+    // array of two 32bit ints) shifted left by that number of positions.
+    //
+    x64LeftShift: function(m, n) {
+      n %= 64;
+      if (n === 0) {
+        return m;
+      }
+      else if (n < 32) {
+        return [(m[0] << n) | (m[1] >>> (32 - n)), m[1] << n];
+      }
+      else {
+        return [m[1] << (n - 32), 0];
+      }
+    },
+    //
+    // Given two 64bit ints (as an array of two 32bit ints) returns the two
+    // xored together as a 64bit int (as an array of two 32bit ints).
+    //
+    x64Xor: function(m, n) {
+      return [m[0] ^ n[0], m[1] ^ n[1]];
+    },
+    //
+    // Given a block, returns murmurHash3's final x64 mix of that block.
+    // (`[0, h[0] >>> 1]` is a 33 bit unsigned right shift. This is the
+    // only place where we need to right shift 64bit ints.)
+    //
+    x64Fmix: function(h) {
+      h = this.x64Xor(h, [0, h[0] >>> 1]);
+      h = this.x64Multiply(h, [0xff51afd7, 0xed558ccd]);
+      h = this.x64Xor(h, [0, h[0] >>> 1]);
+      h = this.x64Multiply(h, [0xc4ceb9fe, 0x1a85ec53]);
+      h = this.x64Xor(h, [0, h[0] >>> 1]);
+      return h;
+    },
 
-      h1 ^= key.length;
-
-      h1 ^= h1 >>> 16;
-      h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
-      h1 ^= h1 >>> 13;
-      h1 = ((((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff;
-      h1 ^= h1 >>> 16;
-
-      return h1 >>> 0;
+    //
+    // Given a string and an optional seed as an int, returns a 128 bit
+    // hash using the x64 flavor of MurmurHash3, as an unsigned hex.
+    //
+    x64hash128: function (key, seed) {
+      key = key || "";
+      seed = seed || 0;
+      var remainder = key.length % 16;
+      var bytes = key.length - remainder;
+      var h1 = [0, seed];
+      var h2 = [0, seed];
+      var k1 = [0, 0];
+      var k2 = [0, 0];
+      var c1 = [0x87c37b91, 0x114253d5];
+      var c2 = [0x4cf5ad43, 0x2745937f];
+      for (var i = 0; i < bytes; i = i + 16) {
+        k1 = [((key.charCodeAt(i + 4) & 0xff)) | ((key.charCodeAt(i + 5) & 0xff) << 8) | ((key.charCodeAt(i + 6) & 0xff) << 16) | ((key.charCodeAt(i + 7) & 0xff) << 24), ((key.charCodeAt(i) & 0xff)) | ((key.charCodeAt(i + 1) & 0xff) << 8) | ((key.charCodeAt(i + 2) & 0xff) << 16) | ((key.charCodeAt(i + 3) & 0xff) << 24)];
+        k2 = [((key.charCodeAt(i + 12) & 0xff)) | ((key.charCodeAt(i + 13) & 0xff) << 8) | ((key.charCodeAt(i + 14) & 0xff) << 16) | ((key.charCodeAt(i + 15) & 0xff) << 24), ((key.charCodeAt(i + 8) & 0xff)) | ((key.charCodeAt(i + 9) & 0xff) << 8) | ((key.charCodeAt(i + 10) & 0xff) << 16) | ((key.charCodeAt(i + 11) & 0xff) << 24)];
+        k1 = this.x64Multiply(k1, c1);
+        k1 = this.x64Rotl(k1, 31);
+        k1 = this.x64Multiply(k1, c2);
+        h1 = this.x64Xor(h1, k1);
+        h1 = this.x64Rotl(h1, 27);
+        h1 = this.x64Add(h1, h2);
+        h1 = this.x64Add(this.x64Multiply(h1, [0, 5]), [0, 0x52dce729]);
+        k2 = this.x64Multiply(k2, c2);
+        k2 = this.x64Rotl(k2, 33);
+        k2 = this.x64Multiply(k2, c1);
+        h2 = this.x64Xor(h2, k2);
+        h2 = this.x64Rotl(h2, 31);
+        h2 = this.x64Add(h2, h1);
+        h2 = this.x64Add(this.x64Multiply(h2, [0, 5]), [0, 0x38495ab5]);
+      }
+      k1 = [0, 0];
+      k2 = [0, 0];
+      switch(remainder) {
+        case 15:
+          k2 = this.x64Xor(k2, this.x64LeftShift([0, key.charCodeAt(i + 14)], 48));
+        case 14:
+          k2 = this.x64Xor(k2, this.x64LeftShift([0, key.charCodeAt(i + 13)], 40));
+        case 13:
+          k2 = this.x64Xor(k2, this.x64LeftShift([0, key.charCodeAt(i + 12)], 32));
+        case 12:
+          k2 = this.x64Xor(k2, this.x64LeftShift([0, key.charCodeAt(i + 11)], 24));
+        case 11:
+          k2 = this.x64Xor(k2, this.x64LeftShift([0, key.charCodeAt(i + 10)], 16));
+        case 10:
+          k2 = this.x64Xor(k2, this.x64LeftShift([0, key.charCodeAt(i + 9)], 8));
+        case 9:
+          k2 = this.x64Xor(k2, [0, key.charCodeAt(i + 8)]);
+          k2 = this.x64Multiply(k2, c2);
+          k2 = this.x64Rotl(k2, 33);
+          k2 = this.x64Multiply(k2, c1);
+          h2 = this.x64Xor(h2, k2);
+        case 8:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 7)], 56));
+        case 7:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 6)], 48));
+        case 6:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 5)], 40));
+        case 5:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 4)], 32));
+        case 4:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 3)], 24));
+        case 3:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 2)], 16));
+        case 2:
+          k1 = this.x64Xor(k1, this.x64LeftShift([0, key.charCodeAt(i + 1)], 8));
+        case 1:
+          k1 = this.x64Xor(k1, [0, key.charCodeAt(i)]);
+          k1 = this.x64Multiply(k1, c1);
+          k1 = this.x64Rotl(k1, 31);
+          k1 = this.x64Multiply(k1, c2);
+          h1 = this.x64Xor(h1, k1);
+      }
+      h1 = this.x64Xor(h1, [0, key.length]);
+      h2 = this.x64Xor(h2, [0, key.length]);
+      h1 = this.x64Add(h1, h2);
+      h2 = this.x64Add(h2, h1);
+      h1 = this.x64Fmix(h1);
+      h2 = this.x64Fmix(h2);
+      h1 = this.x64Add(h1, h2);
+      h2 = this.x64Add(h2, h1);
+      return ("00000000" + (h1[0] >>> 0).toString(16)).slice(-8) + ("00000000" + (h1[1] >>> 0).toString(16)).slice(-8) + ("00000000" + (h2[0] >>> 0).toString(16)).slice(-8) + ("00000000" + (h2[1] >>> 0).toString(16)).slice(-8);
     },
 
     // https://bugzilla.mozilla.org/show_bug.cgi?id=781447


### PR DESCRIPTION
already done in fingerprintjs2:
https://github.com/Valve/fingerprintjs2/blob/master/fingerprint2.js#L70-L71

on big data sets hash collisions is a real issue

see: https://github.com/Valve/fingerprintjs/issues/30

@Valve /cc